### PR TITLE
Add "docs builds" As CI Test

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -95,6 +95,10 @@ DID_FAIL=0
 export NATIVELINK_DIR="$CACHE_DIR/nativelink"
 mkdir -p "$NATIVELINK_DIR"
 
+# Running "docs builds" to ensure documentation doesn't break
+echo "Running \"docs builds\" to ensure documentation doesn't break"
+docs builds
+
 for pattern in "${TEST_PATTERNS[@]}"; do
   find "$SELF_DIR/integration_tests/" -name "$pattern" -type f -print0 | while IFS= read -r -d $'\0' fullpath; do
     # Cleanup.


### PR DESCRIPTION
# Description

This commit tackles Issue #1082. It runs the command "docs builds" in run_integration_tests.sh, a script executed by main.yaml during CI. This addition should ensure that "docs builds" always runs before merging a PR.
Fixes # (issue)

## Type of change

Please delete options that aren't relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Need some help here – I tested "docs builds" by temporary creating files with invalid rust syntax to examine error codes. I've never worked on editing CI pipelines and was unsure about what further tests to conduct. Any suggestions would be helpful :)